### PR TITLE
Temporary Fix: Set denite compatible commit

### DIFF
--- a/config/nvim/plugins.vim
+++ b/config/nvim/plugins.vim
@@ -38,7 +38,7 @@ Plug 'neoclide/coc.nvim', {'tag': '*', 'do': { -> coc#util#install()}}
 Plug 'christoomey/vim-tmux-navigator'
 
 " Denite - Fuzzy finding, buffer management
-Plug 'Shougo/denite.nvim'
+Plug 'Shougo/denite.nvim', { 'commit': '29bfd4c53271c7a150def2388e059746ae4c1713' }
 
 " Snippet support
 Plug 'Shougo/neosnippet'


### PR DESCRIPTION
If anyone tries to install Jarvis today it will not work due to issue #20.

This PR temporarily fixes that, specifying a compatible Denite commit (the last commit from 2.0 version).