### PR TITLE
Fix vim-airline theme installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -126,7 +126,7 @@ echo "---------------------------------------------------------"
 echo "$(tput setaf 2)JARVIS: Installing Space vim-airline theme.$(tput sgr 0)"
 echo "---------------------------------------------------------"
 
-cp ./config/nvim/space.vim ./config/nvim/plugged/vim-airline-themes/autoload/airline/themes/space.vim
+cp ~/.config/nvim/space.vim ~/.local/share/nvim/plugged/vim-airline-themes/autoload/airline/themes/space.vim
 
 echo "---------------------------------------------------------"
 echo "$(tput setaf 2)JARVIS: Installing tmux plugin manager.$(tput sgr 0)"


### PR DESCRIPTION
When using the installer script and opening vim afterwards, airline was broken, as it couldn't find the theme.

I updated the command that moves the theme to the other themes of `vim-airline-themes`.