### PR TITLE
Only quit filter buffer and leave denite buffer on <C-o>

### DIFF
--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -341,7 +341,7 @@ nnoremap <leader>j :<C-u>DeniteCursorWord grep:.<CR>
 autocmd FileType denite-filter call s:denite_filter_my_settings()
 function! s:denite_filter_my_settings() abort
   imap <silent><buffer> <C-o>
-  \ <Plug>(denite_filter_quit)
+  \ <Plug>(denite_filter_update)
   inoremap <silent><buffer><expr> <Esc>
   \ denite#do_map('quit')
   nnoremap <silent><buffer><expr> <Esc>


### PR DESCRIPTION
When "\<C-o\>" is pressed, it closes both filter buffer and denie buffer per https://github.com/Shougo/denite.nvim/blob/master/doc/denite.txt#L448. Changing it to `denite_filter_update` https://github.com/Shougo/denite.nvim/blob/master/doc/denite.txt#L453 will only close the filter, moving the cursor to the denite buffer for you to search the list